### PR TITLE
MPDP-685 Create core repo

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,7 @@ services:
       AWS_SECRET_ACCESS_KEY: test
       AWS_SECRET_KEY: test
       AWS_REGION: eu-west-2
-      S3_ENDPOINT: 'http://localstack:4566'
+      S3_ENDPOINT: 'http://fcp-mpdp-frontend-localstack:4566'
       RESULTS_OUTPUT_S3_PATH: 's3://fcp-mpdp-performance-test-suite'
       ENVIRONMENT: local
       DOMAIN: fcp-mpdp-frontend

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,6 @@
 services:
   development:
+    container_name: fcp-mpdp-performance-test-suite-development
     build: .
     volumes:
       - ./reports:/opt/perftest/reports

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,6 +2,11 @@ services:
   development:
     container_name: fcp-mpdp-performance-test-suite-development
     build: .
+    links:
+      - 'localstack:localstack'
+    depends_on:
+      localstack:
+        condition: service_healthy
     volumes:
       - ./reports:/opt/perftest/reports
     environment:
@@ -22,11 +27,11 @@ services:
     image: localstack/localstack:3.0.2
     container_name: fcp-mpdp-performance-test-suite-localstack
     ports:
-      - '4566:4566' # LocalStack Gateway
-      - '4510-4559:4510-4559' # external services port range
+      - '4566:4566' 
+      - '4510-4559:4510-4559'
     environment:
       DEBUG: ${DEBUG:-1}
-      LS_LOG: WARN # Localstack DEBUG Level
+      LS_LOG: WARN
       SERVICES: s3,sqs,sns,firehose
       LOCALSTACK_HOST: 127.0.0.1
       AWS_REGION: eu-west-2

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,12 +9,38 @@ services:
       AWS_SECRET_ACCESS_KEY: test
       AWS_SECRET_KEY: test
       AWS_REGION: eu-west-2
-      S3_ENDPOINT: 'http://fcp-mpdp-frontend-localstack:4566'
+      S3_ENDPOINT: 'http://fcp-mpdp-performance-test-suite-localstack:4566'
       RESULTS_OUTPUT_S3_PATH: 's3://fcp-mpdp-performance-test-suite'
       ENVIRONMENT: local
       DOMAIN: development
       LOCAL_PORT: 3000
       PROTOCOL: http
+    networks:
+      - fcp-mpdp
+
+  localstack:
+    image: localstack/localstack:3.0.2
+    container_name: fcp-mpdp-performance-test-suite-localstack
+    ports:
+      - '4566:4566' # LocalStack Gateway
+      - '4510-4559:4510-4559' # external services port range
+    environment:
+      DEBUG: ${DEBUG:-1}
+      LS_LOG: WARN # Localstack DEBUG Level
+      SERVICES: s3,sqs,sns,firehose
+      LOCALSTACK_HOST: 127.0.0.1
+      AWS_REGION: eu-west-2
+      AWS_DEFAULT_REGION: eu-west-2
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+    volumes:
+      - '${TMPDIR:-/tmp}/localstack:/var/lib/localstack'
+      - ./compose/start-localstack.sh:/etc/localstack/init/ready.d/start-localstack.sh
+    healthcheck:
+      test: ['CMD', 'curl', 'localhost:4566']
+      interval: 5s
+      start_period: 5s
+      retries: 3
     networks:
       - fcp-mpdp
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,7 @@ services:
       S3_ENDPOINT: 'http://fcp-mpdp-frontend-localstack:4566'
       RESULTS_OUTPUT_S3_PATH: 's3://fcp-mpdp-performance-test-suite'
       ENVIRONMENT: local
-      DOMAIN: fcp-mpdp-frontend
+      DOMAIN: development
       LOCAL_PORT: 3000
       PROTOCOL: http
     networks:

--- a/test.sh
+++ b/test.sh
@@ -8,12 +8,12 @@ echo "Starting fcp-mpdp-performance-test-suite Docker container..."
 docker compose up --build -d 
 
 echo "Creating S3 bucket: $BUCKET_NAME..."
-docker compose exec development aws --endpoint-url=http://fcp-mpdp-frontend-localstack:4566 s3 mb "s3://$BUCKET_NAME" 
+docker compose exec development aws --endpoint-url=http://fcp-mpdp-performance-test-suite-localstack:4566 s3 mb "s3://$BUCKET_NAME" 
 echo "S3 bucket: $BUCKET_NAME successfully created"
 
 echo "Waiting for S3 bucket $BUCKET_NAME to become accessible..."
 for i in {1..10}; do
-  if docker compose exec development aws s3 ls "s3://$BUCKET_NAME" --endpoint-url=http://fcp-mpdp-frontend-localstack:4566 > /dev/null 2>&1; then
+  if docker compose exec development aws s3 ls "s3://$BUCKET_NAME" --endpoint-url=http://fcp-mpdp-performance-test-suite-localstack:4566 > /dev/null 2>&1; then
     echo "S3 bucket fcp-mpdp-performance-test-suite is now accessible"
     break
   fi
@@ -30,6 +30,6 @@ rm -rf "${LOCAL_REPORTS_DIR:?}"/*
 mkdir -p "$LOCAL_REPORTS_DIR"
 
 echo "Downloading reports from S3 bucket $BUCKET_NAME..."
-docker compose exec development aws s3 cp "s3://$BUCKET_NAME/" "/opt/perftest/reports" --recursive --endpoint-url=http://fcp-mpdp-frontend-localstack:4566
+docker compose exec development aws s3 cp "s3://$BUCKET_NAME/" "/opt/perftest/reports" --recursive --endpoint-url=http://fcp-mpdp-performance-test-suite-localstack:4566
 
 echo "Reports have been downloaded successfully"

--- a/test.sh
+++ b/test.sh
@@ -8,14 +8,28 @@ echo "Starting fcp-mpdp-performance-test-suite Docker container..."
 docker compose up --build -d 
 
 echo "Creating S3 bucket: $BUCKET_NAME..."
-docker compose exec development aws --endpoint-url=http://localstack:4566 s3 mb "s3://$BUCKET_NAME" 
+docker compose exec development aws --endpoint-url=http://fcp-mpdp-frontend-localstack:4566 s3 mb "s3://$BUCKET_NAME" 
 echo "S3 bucket: $BUCKET_NAME successfully created"
+
+echo "Waiting for S3 bucket $BUCKET_NAME to become accessible..."
+for i in {1..10}; do
+  if docker compose exec development aws s3 ls "s3://$BUCKET_NAME" --endpoint-url=http://fcp-mpdp-frontend-localstack:4566 > /dev/null 2>&1; then
+    echo "S3 bucket fcp-mpdp-performance-test-suite is now accessible"
+    break
+  fi
+  echo "S3 bucket fcp-mpdp-performance-test-suite is not yet accessible, retrying in 2 seconds..."
+  sleep 2
+  if [ "$i" -eq 10 ]; then
+    echo "ERROR: S3 bucket $BUCKET_NAME is still not accessible after 10 attempts."
+    exit 1
+  fi
+done
 
 echo "Clearing local reports directory: $LOCAL_REPORTS_DIR"
 rm -rf "${LOCAL_REPORTS_DIR:?}"/*
 mkdir -p "$LOCAL_REPORTS_DIR"
 
 echo "Downloading reports from S3 bucket $BUCKET_NAME..."
-docker compose exec development aws s3 cp "s3://$BUCKET_NAME/" "/opt/perftest/reports" --recursive --endpoint-url=http://localstack:4566
+docker compose exec development aws s3 cp "s3://$BUCKET_NAME/" "/opt/perftest/reports" --recursive --endpoint-url=http://fcp-mpdp-frontend-localstack:4566
 
 echo "Reports have been downloaded successfully"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/MPDP-685
PR to update the localstack endpoint so that it points to the frontend localstack Docker service to avoid conflicts with the backend localstack service. There is discussion on whether these are even needed but as that will be further discussed as part of MPDP-734 & MPDP-735 this PR is the suggested fix for the time being.

